### PR TITLE
feat: persist quiz answer history

### DIFF
--- a/src/lib/answer-history.ts
+++ b/src/lib/answer-history.ts
@@ -1,0 +1,34 @@
+import { supabase } from "@/integrations/supabase/client";
+import { UserAnswer } from "@/lib/types";
+
+const TABLE_NAME = "answer_history";
+
+export async function saveAnswerHistory(sessionId: string, answer: UserAnswer) {
+  const { error } = await supabase.from(TABLE_NAME).insert({
+    session_id: sessionId,
+    question_id: answer.questionId,
+    answer: answer.answer,
+    time_spent: answer.timeSpent,
+    is_correct: answer.isCorrect,
+    grade: answer.grade,
+  });
+
+  if (error) {
+    console.error("Failed to save answer history", error);
+  }
+}
+
+export async function fetchAnswerHistory(sessionId: string) {
+  const { data, error } = await supabase
+    .from(TABLE_NAME)
+    .select("*")
+    .eq("session_id", sessionId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    console.error("Failed to fetch answer history", error);
+    return [];
+  }
+
+  return data ?? [];
+}

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -6,6 +6,7 @@ import { subjects } from "@/data/questions";
 import { SpacedRepetitionScheduler } from "@/lib/scheduler";
 import { UserAnswer, Card, Question } from "@/lib/types";
 import { ArrowLeft, RotateCcw } from "lucide-react";
+import { saveAnswerHistory } from "@/lib/answer-history";
 
 export default function Quiz() {
   const { unitId } = useParams<{ unitId: string }>();
@@ -16,6 +17,7 @@ export default function Quiz() {
   const [showResult, setShowResult] = useState(false);
   const [cards, setCards] = useState<Card[]>([]);
   const [isComplete, setIsComplete] = useState(false);
+  const [sessionId] = useState(() => crypto.randomUUID());
 
   // Find unit and questions or handle review-all case
   let unit, questions;
@@ -93,6 +95,7 @@ export default function Quiz() {
 
     setAnswers(prev => [...prev, userAnswer]);
     setShowResult(true);
+    void saveAnswerHistory(sessionId, userAnswer);
 
     // Update card with spaced repetition
     const cardIndex = cards.findIndex(c => c.questionId === currentQuestion.id);


### PR DESCRIPTION
## Summary
- store quiz answers in Supabase `answer_history` table
- tag each session with UUID and log answers after each question

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aac0ee8f408328b540f556cb2c5b92