### PR TITLE
Add resume quiz option with progress tracking

### DIFF
--- a/src/lib/quiz-progress.ts
+++ b/src/lib/quiz-progress.ts
@@ -1,0 +1,41 @@
+const STORAGE_KEY = 'quizProgress';
+
+interface ProgressMap {
+  [unitId: string]: number;
+}
+
+function loadProgress(): ProgressMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveProgressMap(map: ProgressMap): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // ignore
+  }
+}
+
+export function getQuizProgress(unitId: string): number {
+  const map = loadProgress();
+  return map[unitId] ?? 0;
+}
+
+export function saveQuizProgress(unitId: string, index: number): void {
+  const map = loadProgress();
+  map[unitId] = index;
+  saveProgressMap(map);
+}
+
+export function clearQuizProgress(unitId: string): void {
+  const map = loadProgress();
+  delete map[unitId];
+  saveProgressMap(map);
+}

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -71,14 +71,13 @@ export default function Quiz() {
   }, [questions]);
 
   useEffect(() => {
-    if (unitId) {
-      const saved = getQuizProgress(unitId);
-      if (saved > 0 && saved < questions.length) {
-        setResumePrompt(true);
-        setSavedIndex(saved);
-      }
+    if (!unitId || questions.length === 0) return;
+    const saved = getQuizProgress(unitId);
+    if (saved > 0 && saved < questions.length) {
+      setResumePrompt(true);
+      setSavedIndex(saved);
     }
-  }, [unitId, questions]);
+  }, [unitId, questions.length]);
 
   if (!unit || questions.length === 0) {
     return (
@@ -104,6 +103,8 @@ export default function Quiz() {
               className="gradient-primary"
               onClick={() => {
                 setCurrentQuestionIndex(savedIndex);
+                setShowResult(false);
+                setAnswers([]);
                 setResumePrompt(false);
               }}
             >
@@ -114,6 +115,8 @@ export default function Quiz() {
               onClick={() => {
                 clearQuizProgress(unitId!);
                 setCurrentQuestionIndex(0);
+                setShowResult(false);
+                setAnswers([]);
                 setResumePrompt(false);
               }}
             >


### PR DESCRIPTION
## Summary
- track quiz progress per unit in local storage
- offer "continue from last question" or "start over" when starting a quiz
- save and clear progress as users answer, finish, or restart quizzes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aace86cc148328813629bb3f98fa7d