### PR TITLE
Enhance quiz readability and add daily progress chart

### DIFF
--- a/src/components/daily-progress-chart.tsx
+++ b/src/components/daily-progress-chart.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer } from "recharts";
+import { getDailyAnswerCounts } from "@/lib/answer-stats";
+
+export function DailyProgressChart() {
+  const [data, setData] = useState<{ date: string; count: number }[]>([]);
+
+  useEffect(() => {
+    setData(getDailyAnswerCounts());
+  }, []);
+
+  return (
+    <div className="w-full h-40">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <XAxis dataKey="date" />
+          <Tooltip />
+          <Bar dataKey="count" fill="hsl(var(--primary))" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -171,11 +171,11 @@ All colors MUST be HSL.
   }
 
   .quiz-answer-correct {
-    @apply bg-success/10 border-success text-success-foreground;
+    @apply bg-success/10 border-success text-success;
   }
 
   .quiz-answer-incorrect {
-    @apply bg-destructive/10 border-destructive text-destructive-foreground;
+    @apply bg-destructive/10 border-destructive text-destructive;
   }
 
   .progress-ring {

--- a/src/lib/answer-stats.ts
+++ b/src/lib/answer-stats.ts
@@ -5,6 +5,7 @@ interface QuestionStats {
 }
 
 const STORAGE_KEY = 'questionStats';
+const DAILY_KEY = 'dailyAnswerCounts';
 
 function loadStats(): Record<string, QuestionStats> {
   if (typeof window === 'undefined') return {};
@@ -25,6 +26,32 @@ function saveStats(stats: Record<string, QuestionStats>): void {
   }
 }
 
+function loadDailyCounts(): Record<string, number> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(DAILY_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveDailyCounts(counts: Record<string, number>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DAILY_KEY, JSON.stringify(counts));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function recordDailyAnswer(): void {
+  const counts = loadDailyCounts();
+  const today = new Date().toISOString().slice(0, 10);
+  counts[today] = (counts[today] || 0) + 1;
+  saveDailyCounts(counts);
+}
+
 export function updateQuestionStats(questionId: string, isCorrect: boolean): void {
   const stats = loadStats();
   const current = stats[questionId] || { correct: 0, total: 0, lastResult: false };
@@ -33,6 +60,7 @@ export function updateQuestionStats(questionId: string, isCorrect: boolean): voi
   current.lastResult = isCorrect;
   stats[questionId] = current;
   saveStats(stats);
+  recordDailyAnswer();
 }
 
 export function getQuestionStats(questionId: string): QuestionStats | null {
@@ -42,6 +70,20 @@ export function getQuestionStats(questionId: string): QuestionStats | null {
 
 export function getAllQuestionStats(): Record<string, QuestionStats> {
   return loadStats();
+}
+
+export function getDailyAnswerCounts(days = 7): { date: string; count: number }[] {
+  if (typeof window === 'undefined') return [];
+  const counts = loadDailyCounts();
+  const result: { date: string; count: number }[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    const label = `${d.getMonth() + 1}/${d.getDate()}`;
+    result.push({ date: label, count: counts[key] ?? 0 });
+  }
+  return result;
 }
 
 export function getLowAccuracyQuestionIds(threshold = 0.7): string[] {

--- a/src/pages/SubjectList.tsx
+++ b/src/pages/SubjectList.tsx
@@ -1,6 +1,7 @@
 import { SubjectCard } from "@/components/subject-card";
 import { subjects } from "@/data/questions";
 import { GraduationCap, BarChart3, RefreshCw, BookOpen } from "lucide-react";
+import { DailyProgressChart } from "@/components/daily-progress-chart";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -129,11 +130,12 @@ export default function SubjectList() {
           ))}
         </div>
 
-        <div className="mt-12 text-center">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 rounded-full text-sm text-primary">
-            <span>🧠</span>
-            <span>SM-2アルゴリズムによる最適化された復習スケジュール</span>
-          </div>
+        <div className="mt-12">
+          <h3 className="text-lg font-bold mb-4 flex items-center gap-2">
+            <BarChart3 className="h-5 w-5 text-primary" />
+            毎日の回答数
+          </h3>
+          <DailyProgressChart />
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Improve answer feedback contrast for better readability
- Track daily answer counts and visualize them on the subject list page
- Remove SM-2 algorithm banner from the dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1109dbbac8328a1da00914fdfea99