### PR TITLE
Enhance quiz readability and add daily progress chart

### DIFF
--- a/src/components/daily-progress-chart.tsx
+++ b/src/components/daily-progress-chart.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { BarChart, Bar, XAxis, Tooltip, ResponsiveContainer, ReferenceLine } from "recharts";
+import { getMonthlyAnswerCounts } from "@/lib/answer-stats";
+
+interface Props {
+  target: number;
+}
+
+export function DailyProgressChart({ target }: Props) {
+  const [data, setData] = useState<{ date: string; count: number }[]>([]);
+
+  useEffect(() => {
+    const now = new Date();
+    setData(getMonthlyAnswerCounts(now.getFullYear(), now.getMonth()));
+  }, []);
+
+  return (
+    <div className="w-full h-40">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data}>
+          <XAxis dataKey="date" />
+          <Tooltip />
+          <Bar dataKey="count" fill="hsl(var(--primary))" />
+          {target > 0 && (
+            <ReferenceLine
+              y={target}
+              stroke="hsl(var(--secondary))"
+              strokeDasharray="4 4"
+              label="目標"
+            />
+          )}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -171,11 +171,11 @@ All colors MUST be HSL.
   }
 
   .quiz-answer-correct {
-    @apply bg-success/10 border-success text-success-foreground;
+    @apply bg-success/10 border-success text-success;
   }
 
   .quiz-answer-incorrect {
-    @apply bg-destructive/10 border-destructive text-destructive-foreground;
+    @apply bg-destructive/10 border-destructive text-destructive;
   }
 
   .progress-ring {

--- a/src/lib/answer-stats.ts
+++ b/src/lib/answer-stats.ts
@@ -5,6 +5,8 @@ interface QuestionStats {
 }
 
 const STORAGE_KEY = 'questionStats';
+const DAILY_KEY = 'dailyAnswerCounts';
+const TARGET_KEY = 'dailyTargetCount';
 
 function loadStats(): Record<string, QuestionStats> {
   if (typeof window === 'undefined') return {};
@@ -25,6 +27,51 @@ function saveStats(stats: Record<string, QuestionStats>): void {
   }
 }
 
+function loadDailyCounts(): Record<string, number> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(DAILY_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveDailyCounts(counts: Record<string, number>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(DAILY_KEY, JSON.stringify(counts));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function loadTarget(): number {
+  if (typeof window === 'undefined') return 0;
+  try {
+    const raw = window.localStorage.getItem(TARGET_KEY);
+    return raw ? Number(raw) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function saveTarget(target: number): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(TARGET_KEY, String(target));
+  } catch {
+    // ignore write errors
+  }
+}
+
+function recordDailyAnswer(): void {
+  const counts = loadDailyCounts();
+  const today = new Date().toISOString().slice(0, 10);
+  counts[today] = (counts[today] || 0) + 1;
+  saveDailyCounts(counts);
+}
+
 export function updateQuestionStats(questionId: string, isCorrect: boolean): void {
   const stats = loadStats();
   const current = stats[questionId] || { correct: 0, total: 0, lastResult: false };
@@ -33,6 +80,7 @@ export function updateQuestionStats(questionId: string, isCorrect: boolean): voi
   current.lastResult = isCorrect;
   stats[questionId] = current;
   saveStats(stats);
+  recordDailyAnswer();
 }
 
 export function getQuestionStats(questionId: string): QuestionStats | null {
@@ -42,6 +90,42 @@ export function getQuestionStats(questionId: string): QuestionStats | null {
 
 export function getAllQuestionStats(): Record<string, QuestionStats> {
   return loadStats();
+}
+
+export function getDailyAnswerCounts(days = 7): { date: string; count: number }[] {
+  if (typeof window === 'undefined') return [];
+  const counts = loadDailyCounts();
+  const result: { date: string; count: number }[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const key = d.toISOString().slice(0, 10);
+    const label = `${d.getMonth() + 1}/${d.getDate()}`;
+    result.push({ date: label, count: counts[key] ?? 0 });
+  }
+  return result;
+}
+
+export function getMonthlyAnswerCounts(year: number, month: number): { date: string; count: number }[] {
+  if (typeof window === 'undefined') return [];
+  const counts = loadDailyCounts();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const result: { date: string; count: number }[] = [];
+  for (let day = 1; day <= daysInMonth; day++) {
+    const d = new Date(year, month, day);
+    const key = d.toISOString().slice(0, 10);
+    const label = `${month + 1}/${day}`;
+    result.push({ date: label, count: counts[key] ?? 0 });
+  }
+  return result;
+}
+
+export function getDailyTarget(): number {
+  return loadTarget();
+}
+
+export function setDailyTarget(target: number): void {
+  saveTarget(target);
 }
 
 export function getLowAccuracyQuestionIds(threshold = 0.7): string[] {

--- a/src/pages/SubjectList.tsx
+++ b/src/pages/SubjectList.tsx
@@ -1,14 +1,19 @@
 import { SubjectCard } from "@/components/subject-card";
 import { subjects } from "@/data/questions";
 import { GraduationCap, BarChart3, RefreshCw, BookOpen } from "lucide-react";
+import { DailyProgressChart } from "@/components/daily-progress-chart";
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { getAllQuestionStats, getLowAccuracyQuestionIds } from "@/lib/answer-stats";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getAllQuestionStats, getLowAccuracyQuestionIds, getDailyTarget, setDailyTarget } from "@/lib/answer-stats";
 
 export default function SubjectList() {
   const navigate = useNavigate();
+  const [target, setTarget] = useState<number>(getDailyTarget());
 
   const handleStartLearning = (subjectId: string) => {
     navigate(`/subjects/${subjectId}`);
@@ -43,6 +48,12 @@ export default function SubjectList() {
   const totalNewCards = updatedSubjects.reduce((sum, subject) =>
     sum + subject.units.reduce((unitSum, unit) => unitSum + unit.newCards, 0), 0
   );
+
+  const handleTargetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(e.target.value);
+    setTarget(value);
+    setDailyTarget(value);
+  };
 
   return (
     <div className="min-h-screen gradient-learning">
@@ -129,11 +140,24 @@ export default function SubjectList() {
           ))}
         </div>
 
-        <div className="mt-12 text-center">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 rounded-full text-sm text-primary">
-            <span>🧠</span>
-            <span>SM-2アルゴリズムによる最適化された復習スケジュール</span>
+        <div className="mt-12">
+          <h3 className="text-lg font-bold mb-4 flex items-center gap-2">
+            <BarChart3 className="h-5 w-5 text-primary" />
+            毎日の回答数
+          </h3>
+          <div className="flex items-center gap-2 mb-4">
+            <Label htmlFor="target" className="text-sm">
+              目標
+            </Label>
+            <Input
+              id="target"
+              type="number"
+              value={target}
+              onChange={handleTargetChange}
+              className="w-24 h-8"
+            />
           </div>
+          <DailyProgressChart target={target} />
         </div>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Track daily answers for the current month and persist a user-defined goal
- Visualize monthly progress with a goal reference line
- Allow setting a daily answer target from the subject list page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1109dbbac8328a1da00914fdfea99