### PR TITLE
perf: optimize ranking display

### DIFF
--- a/src/components/ranking-card.tsx
+++ b/src/components/ranking-card.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from 'react';
-import { supabase } from '@/integrations/supabase/client';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Trophy, CalendarCheck } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
+import { useEffect, useRef, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Trophy, CalendarCheck } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { UserProfileCard } from './user-profile-card';
+import { UserProfileCard } from "./user-profile-card";
 
 // データはフラット化されているので、ネストした profiles は不要
 interface RankedUser {
@@ -30,30 +30,29 @@ export function RankingCard() {
   const [ranking, setRanking] = useState<RankedUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState('dailyChallenge');
+  const [activeTab, setActiveTab] = useState("dailyChallenge");
   const [showAll, setShowAll] = useState(false);
+  const cacheRef = useRef<Record<string, { data: RankedUser[]; ts: number }>>({});
+  const CACHE_TTL = 5 * 60 * 1000;
 
   useEffect(() => {
     const fetchRanking = async () => {
+      const cached = cacheRef.current[activeTab];
+      if (cached && Date.now() - cached.ts < CACHE_TTL) {
+        setRanking(cached.data);
+        setLoading(false);
+        return;
+      }
+
       setLoading(true);
       setError(null);
 
-      let functionName = '';
-      switch (activeTab) {
-        case 'dailyChallenge':
-          functionName = 'get-daily-challenge-ranking';
-          break;
-        case 'dailyStudy':
-          functionName = 'get-daily-study-ranking';
-          break;
-        case 'weeklyStudy':
-          functionName = 'get-weekly-study-ranking';
-          break;
-        default:
-          setLoading(false);
-          return;
-      }
-
+      const tabToFunction: Record<string, string> = {
+        dailyChallenge: "get-daily-challenge-ranking",
+        dailyStudy: "get-daily-study-ranking",
+        weeklyStudy: "get-weekly-study-ranking",
+      };
+      const functionName = tabToFunction[activeTab];
       if (!functionName) {
         setRanking([]);
         setLoading(false);
@@ -64,9 +63,11 @@ export function RankingCard() {
 
       if (error) {
         setError(error.message);
-        console.error('Error fetching ranking:', error);
+        console.error("Error fetching ranking:", error);
       } else {
-        setRanking(data || []);
+        const result = data || [];
+        cacheRef.current[activeTab] = { data: result, ts: Date.now() };
+        setRanking(result);
       }
       setLoading(false);
     };
@@ -92,24 +93,32 @@ export function RankingCard() {
     }
 
     if (error) {
-      return <p className="text-sm text-destructive">ランキングの読み込みに失敗しました。</p>;
+      return (
+        <p className="text-sm text-destructive">
+          ランキングの読み込みに失敗しました。
+        </p>
+      );
     }
 
     if (ranking.length === 0) {
-      return <p className="text-sm text-muted-foreground">ランキングはまだありません。</p>;
+      return (
+        <p className="text-sm text-muted-foreground">
+          ランキングはまだありません。
+        </p>
+      );
     }
 
     const getScoreLabel = (user: RankedUser) => {
       switch (activeTab) {
-        case 'dailyChallenge':
+        case "dailyChallenge":
           return `${user.score}点 / ${user.time_taken}秒`;
-        case 'dailyStudy':
-        case 'weeklyStudy':
+        case "dailyStudy":
+        case "weeklyStudy":
           return `${user.count}問`;
         default:
-          return '';
+          return "";
       }
-    }
+    };
 
     const displayedRanking = showAll ? ranking : ranking.slice(0, 3);
 
@@ -119,14 +128,16 @@ export function RankingCard() {
           {displayedRanking.map((user, index) => {
             // 順位に応じてリングのスタイルを決定
             const rankRingClass = [
-              'ring-yellow-400', // 1位: 金
-              'ring-slate-400', // 2位: 銀
-              'ring-orange-800'  // 3位: 銅
+              "ring-yellow-400", // 1位: 金
+              "ring-slate-400", // 2位: 銀
+              "ring-orange-800", // 3位: 銅
             ][index];
 
             return (
               <li key={user.userId} className="flex items-center gap-4">
-                <div className="font-bold text-lg w-6 text-center">{index + 1}</div>
+                <div className="font-bold text-lg w-6 text-center">
+                  {index + 1}
+                </div>
                 <UserProfileCard
                   profile={{
                     username: user.username,
@@ -139,14 +150,23 @@ export function RankingCard() {
                   total_answers={user.total_answers}
                   correct_answers={user.correct_answers}
                 >
-                  <Avatar className={`h-10 w-10 cursor-pointer ${rankRingClass ? `ring-2 ring-offset-2 ring-offset-background ${rankRingClass}` : ''}`}>
-                    <AvatarImage src={user.avatar_url || undefined} alt={user.username || ''} />
-                    <AvatarFallback>{user.username?.charAt(0) || '?'}</AvatarFallback>
+                  <Avatar
+                    className={`h-10 w-10 cursor-pointer ${rankRingClass ? `ring-2 ring-offset-2 ring-offset-background ${rankRingClass}` : ""}`}
+                  >
+                    <AvatarImage
+                      src={user.avatar_url || undefined}
+                      alt={user.username || ""}
+                    />
+                    <AvatarFallback>
+                      {user.username?.charAt(0) || "?"}
+                    </AvatarFallback>
                   </Avatar>
                 </UserProfileCard>
                 <div className="flex-1">
-                  <p className="font-medium">{user.username || '名無しさん'}</p>
-                  <p className="text-sm text-muted-foreground">{getScoreLabel(user)}</p>
+                  <p className="font-medium">{user.username || "名無しさん"}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {getScoreLabel(user)}
+                  </p>
                 </div>
               </li>
             );
@@ -154,8 +174,12 @@ export function RankingCard() {
         </ol>
         {ranking.length > 3 && (
           <div className="mt-4 text-center">
-            <Button variant="ghost" size="sm" onClick={() => setShowAll(prev => !prev)}>
-              {showAll ? '閉じる' : 'もっと見る'}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowAll((prev) => !prev)}
+            >
+              {showAll ? "閉じる" : "もっと見る"}
             </Button>
           </div>
         )}
@@ -171,7 +195,12 @@ export function RankingCard() {
             <Trophy className="h-5 w-5 text-yellow-500" />
             ランキング
           </CardTitle>
-          <Button onClick={() => navigate('/daily-challenge')} size="sm" variant="outline" className="gap-2">
+          <Button
+            onClick={() => navigate("/daily-challenge")}
+            size="sm"
+            variant="outline"
+            className="gap-2"
+          >
             <CalendarCheck className="h-4 w-4" />
             今日の10問に挑戦
           </Button>

--- a/supabase/functions/get-daily-study-ranking/index.ts
+++ b/supabase/functions/get-daily-study-ranking/index.ts
@@ -1,19 +1,22 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
 
 Deno.serve(async (req) => {
-  if (req.method === 'OPTIONS') return new Response('ok', {
-    headers: corsHeaders
-  });
+  if (req.method === "OPTIONS")
+    return new Response("ok", { headers: corsHeaders });
 
   try {
-    const sb = createClient(Deno.env.get('SUPABASE_URL') ?? '', Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '');
-    let categories = [];
+    const sb = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    let categories: string[] = [];
     try {
       const body = await req.json();
       categories = body.categories || [];
-    } catch (e) {
-      categories = [];
+    } catch (_) {
+      /* no body */
     }
 
     const now = new Date();
@@ -21,82 +24,37 @@ Deno.serve(async (req) => {
     jst.setHours(0, 0, 0, 0);
     const fromISO = new Date(jst.getTime() - 9 * 60 * 60 * 1000).toISOString();
 
-    let query = sb.from('answer_logs').select('user_id, created_at').gte('created_at', fromISO);
-    if (categories && Array.isArray(categories) && categories.length > 0) {
-      query = query.in('subject', categories);
-    }
-
-    const { data: logs, error: logsErr } = await query;
-    if (logsErr) throw logsErr;
-
-    const countsMap = (logs || []).reduce((acc, r) => {
-      if (r.user_id) {
-        acc[r.user_id] = (acc[r.user_id] || 0) + 1;
-      }
-      return acc;
-    }, {});
-
-    const ranked = Object.entries(countsMap).map(([userId, count]) => ({
-      userId,
-      count
-    })).sort((a, b) => b.count - a.count).slice(0, 10);
-
-    const userIds = ranked.map((r) => r.userId);
-
-    if (userIds.length === 0) {
-      return new Response(JSON.stringify([]), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 200,
-      });
-    }
-
-    const { data: profilesData, error: profilesErr } = await sb
-      .from('profiles')
-      .select('id, username, avatar_url, bio, department, acquired_qualifications, studying_categories')
-      .in('id', userIds);
-    if (profilesErr) throw profilesErr;
-
-    const profilesById = (profilesData || []).reduce((acc, p) => {
-      acc[p.id] = p;
-      return acc;
-    }, {});
-
-    const { data: statsList, error: statsErr } = await sb.rpc('get_user_stats_for_ranking', { p_user_ids: userIds });
-    if (statsErr) throw statsErr;
-
-    const statsMap = (statsList || []).reduce((acc, stats) => {
-      acc[stats.user_id] = stats;
-      return acc;
-    }, {});
-
-    const result = ranked.map((r) => {
-      const profile = profilesById[r.userId];
-      const stats = statsMap[r.userId] || { total_answers: 0, correct_answers: 0 };
-      return {
-        userId: r.userId,
-        count: r.count,
-        username: profile?.username ?? '名無しさん',
-        avatar_url: profile?.avatar_url ?? null,
-        bio: profile?.bio ?? null,
-        department: profile?.department ?? null,
-        acquired_qualifications: profile?.acquired_qualifications ?? null,
-        studying_categories: profile?.studying_categories ?? [],
-        total_answers: stats.total_answers,
-        correct_answers: stats.correct_answers,
-        score: 0,
-        time_taken: 0
-      };
+    const { data, error } = await sb.rpc("get_daily_study_ranking_v2", {
+      from_time: fromISO,
+      p_categories: categories.length > 0 ? categories : null,
     });
 
+    if (error) throw error;
+
+    const result = (data || []).map((r: any) => ({
+      userId: r.user_id,
+      count: r.count,
+      username: r.username ?? "名無しさん",
+      avatar_url: r.avatar_url ?? null,
+      bio: r.bio ?? null,
+      department: r.department ?? null,
+      acquired_qualifications: r.acquired_qualifications ?? null,
+      studying_categories: r.studying_categories ?? [],
+      total_answers: r.total_answers,
+      correct_answers: r.correct_answers,
+      score: 0,
+      time_taken: 0,
+    }));
+
     return new Response(JSON.stringify(result), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      status: 200
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
     });
   } catch (error) {
     console.error("[get-daily-study-ranking] error:", error);
     return new Response(JSON.stringify({ error: error.message }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      status: 400
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
     });
   }
 });

--- a/supabase/functions/get-weekly-study-ranking/index.ts
+++ b/supabase/functions/get-weekly-study-ranking/index.ts
@@ -1,19 +1,22 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import { corsHeaders } from '../_shared/cors.ts';
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
 
 Deno.serve(async (req) => {
-  if (req.method === 'OPTIONS') return new Response('ok', {
-    headers: corsHeaders
-  });
+  if (req.method === "OPTIONS")
+    return new Response("ok", { headers: corsHeaders });
 
   try {
-    const sb = createClient(Deno.env.get('SUPABASE_URL') ?? '', Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '');
-    let categories = [];
+    const sb = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    let categories: string[] = [];
     try {
       const body = await req.json();
       categories = body.categories || [];
-    } catch (e) {
-      categories = [];
+    } catch (_) {
+      /* no body */
     }
 
     const now = new Date();
@@ -22,84 +25,41 @@ Deno.serve(async (req) => {
     const diff = jstNow.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
     const mondayJST = new Date(jstNow.setDate(diff));
     mondayJST.setHours(0, 0, 0, 0);
-    const fromISO = new Date(mondayJST.getTime() - 9 * 60 * 60 * 1000).toISOString();
+    const fromISO = new Date(
+      mondayJST.getTime() - 9 * 60 * 60 * 1000,
+    ).toISOString();
 
-    let query = sb.from('answer_logs').select('user_id, created_at').gte('created_at', fromISO);
-    if (categories && Array.isArray(categories) && categories.length > 0) {
-      query = query.in('subject', categories);
-    }
-
-    const { data: logs, error: logsErr } = await query;
-    if (logsErr) throw logsErr;
-
-    const countsMap = (logs || []).reduce((acc, r) => {
-      if (r.user_id) {
-        acc[r.user_id] = (acc[r.user_id] || 0) + 1;
-      }
-      return acc;
-    }, {});
-
-    const ranked = Object.entries(countsMap).map(([userId, count]) => ({
-      userId,
-      count
-    })).sort((a, b) => b.count - a.count).slice(0, 10);
-
-    const userIds = ranked.map((r) => r.userId);
-
-    if (userIds.length === 0) {
-      return new Response(JSON.stringify([]), {
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-        status: 200,
-      });
-    }
-
-    const { data: profilesData, error: profilesErr } = await sb
-      .from('profiles')
-      .select('id, username, avatar_url, bio, department, acquired_qualifications, studying_categories')
-      .in('id', userIds);
-    if (profilesErr) throw profilesErr;
-
-    const profilesById = (profilesData || []).reduce((acc, p) => {
-      acc[p.id] = p;
-      return acc;
-    }, {});
-
-    const { data: statsList, error: statsErr } = await sb.rpc('get_user_stats_for_ranking', { p_user_ids: userIds });
-    if (statsErr) throw statsErr;
-
-    const statsMap = (statsList || []).reduce((acc, stats) => {
-      acc[stats.user_id] = stats;
-      return acc;
-    }, {});
-
-    const result = ranked.map((r) => {
-      const profile = profilesById[r.userId];
-      const stats = statsMap[r.userId] || { total_answers: 0, correct_answers: 0 };
-      return {
-        userId: r.userId,
-        count: r.count,
-        username: profile?.username ?? '名無しさん',
-        avatar_url: profile?.avatar_url ?? null,
-        bio: profile?.bio ?? null,
-        department: profile?.department ?? null,
-        acquired_qualifications: profile?.acquired_qualifications ?? null,
-        studying_categories: profile?.studying_categories ?? [],
-        total_answers: stats.total_answers,
-        correct_answers: stats.correct_answers,
-        score: 0,
-        time_taken: 0
-      };
+    const { data, error } = await sb.rpc("get_weekly_study_ranking_v2", {
+      from_time: fromISO,
+      p_categories: categories.length > 0 ? categories : null,
     });
 
+    if (error) throw error;
+
+    const result = (data || []).map((r: any) => ({
+      userId: r.user_id,
+      count: r.count,
+      username: r.username ?? "名無しさん",
+      avatar_url: r.avatar_url ?? null,
+      bio: r.bio ?? null,
+      department: r.department ?? null,
+      acquired_qualifications: r.acquired_qualifications ?? null,
+      studying_categories: r.studying_categories ?? [],
+      total_answers: r.total_answers,
+      correct_answers: r.correct_answers,
+      score: 0,
+      time_taken: 0,
+    }));
+
     return new Response(JSON.stringify(result), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      status: 200
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
     });
   } catch (error) {
     console.error("[get-weekly-study-ranking] error:", error);
     return new Response(JSON.stringify({ error: error.message }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      status: 400
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 400,
     });
   }
 });

--- a/supabase/migrations/20260628000000_create_study_ranking_functions.sql
+++ b/supabase/migrations/20260628000000_create_study_ranking_functions.sql
@@ -1,0 +1,112 @@
+-- 日次・週次ランキングをDB側で集計する関数（3クエリ→1クエリに削減）
+
+CREATE OR REPLACE FUNCTION get_daily_study_ranking_v2(
+  from_time timestamptz,
+  p_categories text[] DEFAULT NULL
+)
+RETURNS TABLE (
+  user_id uuid,
+  count bigint,
+  username text,
+  avatar_url text,
+  bio text,
+  department text,
+  acquired_qualifications text[],
+  studying_categories text[],
+  total_answers bigint,
+  correct_answers bigint
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  WITH ranked AS (
+    SELECT al.user_id, COUNT(*) AS answer_count
+    FROM answer_logs al
+    WHERE al.created_at >= from_time
+      AND (p_categories IS NULL OR cardinality(p_categories) = 0 OR al.subject = ANY(p_categories))
+    GROUP BY al.user_id
+    ORDER BY answer_count DESC
+    LIMIT 10
+  ),
+  stats AS (
+    SELECT al.user_id,
+           COUNT(*) AS total_answers,
+           COUNT(*) FILTER (WHERE al.is_correct) AS correct_answers
+    FROM answer_logs al
+    WHERE al.user_id IN (SELECT r.user_id FROM ranked r)
+    GROUP BY al.user_id
+  )
+  SELECT
+    r.user_id,
+    r.answer_count,
+    COALESCE(p.username, '名無しさん'),
+    p.avatar_url,
+    p.bio,
+    p.department,
+    p.acquired_qualifications,
+    COALESCE(p.studying_categories, ARRAY['ares', 'takken']),
+    COALESCE(s.total_answers, 0),
+    COALESCE(s.correct_answers, 0)
+  FROM ranked r
+  LEFT JOIN profiles p ON p.id = r.user_id
+  LEFT JOIN stats s ON s.user_id = r.user_id
+  ORDER BY r.answer_count DESC;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION get_weekly_study_ranking_v2(
+  from_time timestamptz,
+  p_categories text[] DEFAULT NULL
+)
+RETURNS TABLE (
+  user_id uuid,
+  count bigint,
+  username text,
+  avatar_url text,
+  bio text,
+  department text,
+  acquired_qualifications text[],
+  studying_categories text[],
+  total_answers bigint,
+  correct_answers bigint
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  WITH ranked AS (
+    SELECT al.user_id, COUNT(*) AS answer_count
+    FROM answer_logs al
+    WHERE al.created_at >= from_time
+      AND (p_categories IS NULL OR cardinality(p_categories) = 0 OR al.subject = ANY(p_categories))
+    GROUP BY al.user_id
+    ORDER BY answer_count DESC
+    LIMIT 10
+  ),
+  stats AS (
+    SELECT al.user_id,
+           COUNT(*) AS total_answers,
+           COUNT(*) FILTER (WHERE al.is_correct) AS correct_answers
+    FROM answer_logs al
+    WHERE al.user_id IN (SELECT r.user_id FROM ranked r)
+    GROUP BY al.user_id
+  )
+  SELECT
+    r.user_id,
+    r.answer_count,
+    COALESCE(p.username, '名無しさん'),
+    p.avatar_url,
+    p.bio,
+    p.department,
+    p.acquired_qualifications,
+    COALESCE(p.studying_categories, ARRAY['ares', 'takken']),
+    COALESCE(s.total_answers, 0),
+    COALESCE(s.correct_answers, 0)
+  FROM ranked r
+  LEFT JOIN profiles p ON p.id = r.user_id
+  LEFT JOIN stats s ON s.user_id = r.user_id
+  ORDER BY r.answer_count DESC;
+END;
+$$;
+
+-- created_atにインデックスを追加（時間範囲クエリの高速化）
+CREATE INDEX IF NOT EXISTS idx_answer_logs_created_at ON public.answer_logs (created_at);


### PR DESCRIPTION
## 変更内容

### Edge Functions（daily-study / weekly-study）
- `answer_logs` 全行取得 + JS集計 → SQL `GROUP BY` + `JOIN` の1クエリ（RPC）に変更
- 3クエリ逐次実行（logs → profiles → stats）→ 1回のRPC呼び出しに削減

### フロントエンド（ranking-card.tsx）
- タブ切り替えのたびに再取得していた問題を解消
- 5分間のインメモリキャッシュを追加（`useRef`ベース）

### DB マイグレーション
- `get_daily_study_ranking_v2` / `get_weekly_study_ranking_v2` 関数を追加
- `idx_answer_logs_created_at` インデックスを追加（時間範囲クエリ高速化）

## マージ前の作業
- [ ] Supabase SQL Editorで `supabase/migrations/20260628000000_create_study_ranking_functions.sql` を実行
- [ ] Edge Functions を再デプロイ（マージ後に自動化可）